### PR TITLE
Removed deprecated np.bool

### DIFF
--- a/src/fnnls/fnnls.py
+++ b/src/fnnls/fnnls.py
@@ -71,7 +71,7 @@ def fnnls(Z, x, P_initial = np.zeros(0, dtype=int), lstsq = lambda A, x: np.lina
 
     # A1 + A2
     # P is a boolean array that represents the passive set
-    P = np.zeros(n, dtype=np.bool)
+    P = np.zeros(n, dtype=bool)
     P[P_initial] = True
 
     # A3
@@ -164,7 +164,7 @@ def fix_constraint(ZTZ, ZTx, s, d, P, tolerance, lstsq = lambda A, x: np.linalg.
         The previous estimate of the solution that satisfies
         the nonnegativity contraint
 
-    P: Numpy array, dtype=np.bool
+    P: Numpy array, dtype=bool
         The current passive set, which comtains the indices
         that are not fixed at the value zero. 
 
@@ -185,7 +185,7 @@ def fix_constraint(ZTZ, ZTx, s, d, P, tolerance, lstsq = lambda A, x: np.linalg.
     d: Numpy array
         The updated previous estimate, now as close
         as possible to s while maintaining nonnegativity.
-    P: Numpy array, dtype=np.bool
+    P: Numpy array, dtype=bool
         The updated passive set
         """ 
 


### PR DESCRIPTION
I removed usages of the deprecated `np.bool` alias, which is no longer supported in `numpy`. `fnnls` should now work fine with Python 3.9 as well.

It looks like the _black_ formatter, which I have enabled by default, seems to have made several other changes as well -- just style, not functionality. If you would prefer not to include those, I can revert them.  

**Pull request recommendations:**
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
